### PR TITLE
Fix UpdateTaskStatus substring bug

### DIFF
--- a/core/vault.go
+++ b/core/vault.go
@@ -304,15 +304,20 @@ func UpdateTaskStatus(selected bool, taskDescription string, date time.Time) err
 	lines := strings.Split(string(file), "\n")
 
 	lineUpdated := false
+	pattern := regexp.MustCompile(`^([\t ]*)- \[( |x)\] ?(.*)$`)
+
 	for i, line := range lines {
-		if strings.Contains(line, taskDescription) {
-			if selected {
-				lines[i] = strings.Replace(line, "- [ ]", "- [x]", 1)
-			} else {
-				lines[i] = strings.Replace(line, "- [x]", "- [ ]", 1)
+		if matches := pattern.FindStringSubmatch(line); matches != nil {
+			description := matches[3]
+			if strings.TrimSpace(description) == strings.TrimSpace(taskDescription) {
+				status := " "
+				if selected {
+					status = "x"
+				}
+				lines[i] = fmt.Sprintf("%s- [%s] %s", matches[1], status, description)
+				lineUpdated = true
+				break
 			}
-			lineUpdated = true
-			break
 		}
 	}
 

--- a/core/vault_test.go
+++ b/core/vault_test.go
@@ -184,6 +184,44 @@ func TestUpdateTaskStatus(t *testing.T) {
 	}
 }
 
+func TestUpdateTaskStatusExactMatch(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "vault_test_exact")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	vaultLoc = tempDir
+	intervalMode = "daily"
+
+	testDate := time.Date(2024, 8, 30, 0, 0, 0, 0, time.UTC)
+	filename := getFilename(testDate)
+	initialContent := "- [ ] Task 1\n- [ ] Task 10\n"
+	err = os.MkdirAll(filepath.Dir(filename), 0755)
+	if err != nil {
+		t.Fatalf("Failed to create directories: %v", err)
+	}
+	err = os.WriteFile(filename, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	err = UpdateTaskStatus(true, "Task 1", testDate)
+	if err != nil {
+		t.Errorf("UpdateTaskStatus() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	expectedContent := "- [x] Task 1\n- [ ] Task 10\n"
+	if string(content) != expectedContent {
+		t.Errorf("File content = %v, want %v", string(content), expectedContent)
+	}
+}
+
 func TestNextDateWithWeekendSkipping(t *testing.T) {
 	originalIntervalMode := intervalMode
 	originalSkipWeekend := skipWeekend


### PR DESCRIPTION
## Summary
- fix `UpdateTaskStatus` to match full task description rather than substring
- add regression test ensuring partial matches don't toggle wrong tasks

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683f50cc49d08320a5c4f0fe494c18b0